### PR TITLE
Fix cloth simulation with arbitrary rotations

### DIFF
--- a/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothConstraintSolverSystem.cs
+++ b/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothConstraintSolverSystem.cs
@@ -1,9 +1,7 @@
 ﻿using Unity.Burst;
-using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
 using Unity.Mathematics;
-using UnityEngine;
 
 [UpdateInGroup(typeof(SimulationSystemGroup))]
 [UpdateAfter(typeof(ClothProjectSystem))]

--- a/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothProjectSystem.cs
+++ b/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothProjectSystem.cs
@@ -1,23 +1,22 @@
 ﻿using Unity.Burst;
-using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
 using Unity.Mathematics;
-using UnityEngine;
 
 [UpdateInGroup(typeof(SimulationSystemGroup))]
 [UpdateAfter(typeof(ClothTimestepSystem))]
 public class ClothProjectSystem : JobComponentSystem
 {
     [BurstCompile]
-    struct ProjectClothPositionsJob : IJobForEach_BBBBC<ClothProjectedPosition, ClothCurrentPosition, ClothPreviousPosition, ClothPinWeight, ClothTimestepData>
+    struct ProjectClothPositionsJob : IJobForEach_BBBBCC<ClothProjectedPosition, ClothCurrentPosition, ClothPreviousPosition, ClothPinWeight, ClothTimestepData, ClothWorldToLocal>
     {
         public void Execute(
             DynamicBuffer<ClothProjectedPosition> projectedPositions, 
             DynamicBuffer<ClothCurrentPosition> currentPositions, 
             DynamicBuffer<ClothPreviousPosition> previousPositions, 
             DynamicBuffer<ClothPinWeight> pinWeights, 
-            ref ClothTimestepData timestepData)
+            ref ClothTimestepData timestepData,
+            ref ClothWorldToLocal worldToLocal)
         {
             var fixedStepSq = timestepData.FixedTimestep * timestepData.FixedTimestep;
             
@@ -27,7 +26,7 @@ public class ClothProjectSystem : JobComponentSystem
                 var currentPosition = currentPositions[vertexIndex].Value;
                 
                 var velocity = currentPosition - previousPositions[vertexIndex].Value;
-                var gravity = new float3(0.0f, -9.8f, 0.0f) * fixedStepSq;
+                var gravity = math.mul(worldToLocal.Value, new float4(0.0f, -9.8f, 0.0f, 0.0f)).xyz * fixedStepSq;
                 velocity += gravity;
 
                 var newProjected = currentPosition + velocity * pinWeights[vertexIndex].InvPinWeight;
@@ -39,6 +38,7 @@ public class ClothProjectSystem : JobComponentSystem
     protected override JobHandle OnUpdate(JobHandle inputDependencies)
     {
         var job = new ProjectClothPositionsJob();
+        
         return job.Schedule(this, inputDependencies);
     }
 }

--- a/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothSimRuntimeTypes.cs
+++ b/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothSimRuntimeTypes.cs
@@ -2,8 +2,6 @@
 using System.Runtime.InteropServices;
 using Unity.Entities;
 using Unity.Mathematics;
-using UnityEngine;
-using UnityEngine.Serialization;
 
 [Serializable]
 [InternalBufferCapacity(1024)]
@@ -66,4 +64,11 @@ public struct ClothTimestepData : IComponentData
 {
     public float FixedTimestep;
     public int   IterationCount;
+}
+
+
+[Serializable]
+public struct ClothWorldToLocal : IComponentData
+{
+    public float4x4 Value;
 }

--- a/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothTimestepSystem.cs
+++ b/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/ClothTimestepSystem.cs
@@ -1,7 +1,4 @@
-﻿using Unity.Burst;
-using Unity.Collections;
-using Unity.Entities;
-using Unity.Jobs;
+﻿using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
 

--- a/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/CopyVerticesToMeshSystem.cs
+++ b/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/CopyVerticesToMeshSystem.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using Unity.Burst;
-using Unity.Collections.LowLevel.Unsafe;
+﻿using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
-using Unity.Jobs;
-using Unity.Jobs.LowLevel.Unsafe;
-using Unity.Mathematics;
 using UnityEngine;
 
 [UpdateInGroup(typeof(LateSimulationSystemGroup))]

--- a/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/InitializeClothSystem.cs
+++ b/Ported/ariab/JobCloth/Assets/Scripts/BufferCloth/InitializeClothSystem.cs
@@ -1,19 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
-using Unity.Entities;
 using Unity.Mathematics;
-using Unity.Rendering;
 using UnityEngine;
 
-//[UpdateAfter(typeof(MeshRendererConversion))]
 public unsafe class InitializeClothSystem : GameObjectConversionSystem
 {
     protected override void OnUpdate()
     {
-        Entities.ForEach((MeshFilter meshFilter, VertexClothGarment garment) =>
+        Entities.ForEach((Transform transform, MeshFilter meshFilter, VertexClothGarment garment) =>
         {
             var mesh = meshFilter.mesh;
             var vertexCount = mesh.vertexCount;
@@ -27,7 +23,8 @@ public unsafe class InitializeClothSystem : GameObjectConversionSystem
                 typeof(ClothPinWeight),
                 typeof(ClothTotalTime),
                 typeof(ClothTimestepData),
-                typeof(ClothSourceMeshData));
+                typeof(ClothSourceMeshData),
+                typeof(ClothWorldToLocal));
             var entity = DstEntityManager.CreateEntity(archetype);
             
             // Add reference to source mesh data and set it as read/write
@@ -41,6 +38,7 @@ public unsafe class InitializeClothSystem : GameObjectConversionSystem
             DstEntityManager.SetComponentData(entity, srcMeshData);
             DstEntityManager.SetComponentData(entity, new ClothTotalTime { TotalTime = 0.0f });
             DstEntityManager.SetComponentData(entity, new ClothTimestepData {FixedTimestep = 1.0f / 60.0f, IterationCount = 0});
+            DstEntityManager.SetComponentData(entity, new ClothWorldToLocal { Value = transform.worldToLocalMatrix });
 
             // Copy initial vert data to buffer
             var projectedPositionBuffer = DstEntityManager.GetBuffer<ClothProjectedPosition>(entity);


### PR DESCRIPTION
Added a ClothWorldToLocal which can be propagated into external force calculations during the simulation (i.e. gravity). This caches the WorldToLocal at conversion time (and thus does not support root motion).