### PR TITLE
use Query Builder

### DIFF
--- a/Ported/combat-bees/Assets/Scripts/Systems/BeeSpawnerSystem.cs
+++ b/Ported/combat-bees/Assets/Scripts/Systems/BeeSpawnerSystem.cs
@@ -14,7 +14,7 @@ partial struct BeeSpawnerSystem : ISystem
     [BurstCompile]
     public void OnCreate(ref SystemState state)
     {
-        NestQuery = state.GetEntityQuery(typeof(Faction), typeof(Area));
+        NestQuery = SystemAPI.QueryBuilder().WithAll<Faction, Area>().Build();
         
         // Only need to update if there are any entities with a SpawnRequestQuery
         state.RequireForUpdate(NestQuery);

--- a/Ported/combat-bees/Assets/Scripts/Systems/FoodSpawnerSystem.cs
+++ b/Ported/combat-bees/Assets/Scripts/Systems/FoodSpawnerSystem.cs
@@ -13,7 +13,7 @@ partial struct FoodSpawnerSystem : ISystem
     [BurstCompile]
     public void OnCreate(ref SystemState state)
     {
-        NestQuery = state.GetEntityQuery(typeof(Faction), typeof(Area));
+        NestQuery = SystemAPI.QueryBuilder().WithAll<Area, Faction>().Build();
         
         // This system should not run before the Config singleton has been loaded.
         state.RequireForUpdate<BeeConfig>();

--- a/Ported/combat-bees/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Ported/combat-bees/Assets/Scripts/Systems/MovementSystem.cs
@@ -20,11 +20,12 @@ public struct MovementJob : IJobChunk
 
     public void Execute(in ArchetypeChunk chunk, int unfilteredChunkIndex, bool useEnabledMask, in v128 chunkEnabledMask)
     {
+        var chunkEntityEnumerator = new ChunkEntityEnumerator(useEnabledMask, chunkEnabledMask, chunk.ChunkEntityCount);
         var transforms = chunk.GetNativeArray(TransformHandle);
         var velocities = chunk.GetNativeArray(VelocityHandle);
 
         var gravityDt = TimeStep * Gravity;
-        for (int i = 0; i < chunk.Count; ++i)
+        while (chunkEntityEnumerator.NextEntityIndex(out var i))
         {
             var tmComp = transforms[i];
             var velComp = velocities[i];
@@ -84,7 +85,7 @@ partial struct MovementSystem : ISystem
     [BurstCompile]
     public void OnCreate(ref SystemState state)
     {
-        Query = state.GetEntityQuery(typeof(LocalToWorldTransform), typeof(Velocity));
+        Query = SystemAPI.QueryBuilder().WithAllRW<LocalToWorldTransform, Velocity>().Build();
         TransformHandle = state.GetComponentTypeHandle<LocalToWorldTransform>();
         VelocityHandle = state.GetComponentTypeHandle<Velocity>();
         


### PR DESCRIPTION
Use QueryBuilder instead of managed GetEntityQuery. Fixes Burst error BC1028: Creating a managed array  is not supported.

 Change movement system to use ChunkEntityEnumerator in order to handle enabablable components